### PR TITLE
Update to LiveScript 1.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "livescript-compile",
   "main": "./lib/livescript-compile",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "LiveScript preview/save compiled Javascript in Atom",
   "activationEvents": [
     "livescript-compile:compile"
@@ -12,7 +12,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "LiveScript": "^1.3.x",
+    "LiveScript": ">=1.3.x",
     "underscore-plus": "1.x",
     "loophole": "1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "LiveScript": "^1.2.x",
+    "LiveScript": "^1.3.x",
     "underscore-plus": "1.x",
     "loophole": "1.0.0"
   },


### PR DESCRIPTION
Several changes since 1.2.x. See [LiveScript's changelog](http://livescript.net/#changelog) for more details.

Quick summary of important new features/changes (relevant to this plugin):

- Able to use `that` in switch statements similarly to if statements
- `for let i in array` instead of `for i in array => let`
- Key/value pairs reversed in `require!`, e.g. `require! 'module': mod` instead of `require! mod: 'module'`
- Generators now supported (keeping up with ES6 - V8 and Firefox already ship them as stable)