### PR TITLE
API updated to atom v1.02 compatible

### DIFF
--- a/keymaps/livescript-compile.cson
+++ b/keymaps/livescript-compile.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'atom-text-editor':
   'alt-shift-l': 'livescript-compile:compile'

--- a/lib/livescript-compile-view.coffee
+++ b/lib/livescript-compile-view.coffee
@@ -111,4 +111,4 @@ class  LivescriptCompileView extends ScrollView
       "Compiled Javascript"
 
   getURI:   -> "livescript-compile://editor/#{@editorId}"
-getPath:  -> @editor.getPath()
+  getPath:  -> @editor.getPath()

--- a/lib/livescript-compile.coffee
+++ b/lib/livescript-compile.coffee
@@ -33,7 +33,6 @@ module.exports =
     return unless editor?
 
     grammars = atom.config.get('livescript-compile.grammars') or []
-    console.log editor.getGrammar().scopeName
     unless (grammar = editor.getGrammar().scopeName) in grammars
       console.warn("Cannot compile non-LiveScript to Javascript")
       return

--- a/lib/livescript-compile.coffee
+++ b/lib/livescript-compile.coffee
@@ -1,5 +1,6 @@
 url         = require 'url'
 querystring = require 'querystring'
+{CompositeDisposable} = require 'atom'
 
 LivescriptCompileView = require './livescript-compile-view'
 
@@ -15,9 +16,10 @@ module.exports =
     focusEditorAfterCompile: false
 
   activate: ->
-    atom.workspaceView.command 'livescript-compile:compile', => @display()
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'livescript-compile:compile': => @display()
 
-    atom.workspace.registerOpener (uriToOpen) ->
+    atom.workspace.addOpener (uriToOpen) ->
       {protocol, host, pathname} = url.parse uriToOpen
       pathname = querystring.unescape(pathname) if pathname
 
@@ -25,12 +27,13 @@ module.exports =
       new LivescriptCompileView(pathname.substr(1))
 
   display: ->
-    editor     = atom.workspace.getActiveEditor()
+    editor     = atom.workspace.getActiveTextEditor()
     activePane = atom.workspace.getActivePane()
 
     return unless editor?
 
     grammars = atom.config.get('livescript-compile.grammars') or []
+    console.log editor.getGrammar().scopeName
     unless (grammar = editor.getGrammar().scopeName) in grammars
       console.warn("Cannot compile non-LiveScript to Javascript")
       return
@@ -38,11 +41,11 @@ module.exports =
     uri = "livescript-compile://editor/#{editor.id}"
 
     # If a pane with the uri
-    pane = atom.workspace.paneContainer.paneForUri uri
+    pane = atom.workspace.paneForURI uri
     # If not, always split right
     pane ?= activePane.splitRight()
 
-    atom.workspace.openUriInPane(uri, pane, {}).done (livescriptCompileView) ->
+    atom.workspace.openURIInPane(uri, pane, {}).done (livescriptCompileView) ->
       if livescriptCompileView instanceof LivescriptCompileView
         livescriptCompileView.renderCompiled()
 

--- a/menus/livescript-compile.cson
+++ b/menus/livescript-compile.cson
@@ -1,15 +1,16 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.overlayer':
-      'Enable livescript-compile': 'livescript-compile:compile'
+  'atom-text-editor': [
+    { label: 'Enable livescript-compile', command: 'livescript-compile:compile' }
+  ]
 
-'menu': [
+menu: [
   {
-    'label': 'Packages'
-    'submenu': [
-      'label': 'Livescript Compile'
-      'submenu': [
-        { 'label': 'Compile', 'command': 'livescript-compile:compile' }
+    label: 'Packages'
+    submenu: [
+      label: 'Livescript Compile'
+      submenu: [
+        { label: 'Compile', command: 'livescript-compile:compile' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -3,18 +3,20 @@
   "main": "./lib/livescript-compile",
   "version": "0.1.2",
   "description": "LiveScript preview/save compiled Javascript in Atom",
-  "activationEvents": [
-    "livescript-compile:compile"
-  ],
+  "activationCommands": {
+    "atom-text-editor": "livescript-compile:compile"
+  },
   "repository": "https://github.com/yhsiang/atom-livescript-compile",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.0.2"
   },
   "dependencies": {
     "LiveScript": ">=1.3.x",
-    "underscore-plus": "1.x",
-    "loophole": "1.0.0"
+    "atom-space-pen-views": "^2.0.5",
+    "highlights": "^1.2.0",
+    "loophole": "1.0.0",
+    "underscore-plus": "1.x"
   },
   "devDependencies": {
     "wrench": "^1.5.8",

--- a/spec/livescript-compile-spec.coffee
+++ b/spec/livescript-compile-spec.coffee
@@ -14,7 +14,8 @@ describe "LivescriptCompile", ->
 
     jasmine.unspy window, "setTimeout"
 
-    atom.workspaceView = new WorkspaceView
+    workspaceElement = atom.views.getView(atom.workspace)
+    atom.workspaceView = workspaceElement
     atom.workspace     = atom.workspaceView.model
     spyOn(LivescriptCompileView.prototype, "renderCompiled")
 

--- a/spec/livescript-compile-view-spec.coffee
+++ b/spec/livescript-compile-view-spec.coffee
@@ -1,5 +1,4 @@
 LivescriptCompileView = require '../lib/livescript-compile-view'
-{WorkspaceView} = require 'atom'
 fs = require 'fs'
 
 describe "LivescriptCompileView", ->
@@ -7,12 +6,12 @@ describe "LivescriptCompileView", ->
   editor   = null
 
   beforeEach ->
-    workspaceElement = atom.views.getView(atom.workspace)
-    atom.workspaceView = workspaceElement
-    atom.workspace     = atom.workspaceView.model
+    atom.workspaceView = atom.views.getView(atom.workspace)
 
-    editor = atom.project.openSync('test.ls')
-    compiled = new LivescriptCompileView editor.id
+    waitsForPromise ->
+      atom.workspace.open('test.ls').then (e) ->
+        editor = e
+        compiled = new LivescriptCompileView editor.id
 
     waitsForPromise ->
       atom.packages.activatePackage('language-livescript')

--- a/spec/livescript-compile-view-spec.coffee
+++ b/spec/livescript-compile-view-spec.coffee
@@ -7,8 +7,9 @@ describe "LivescriptCompileView", ->
   editor   = null
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView
-    atom.workspace = atom.workspaceView.model
+    workspaceElement = atom.views.getView(atom.workspace)
+    atom.workspaceView = workspaceElement
+    atom.workspace     = atom.workspaceView.model
 
     editor = atom.project.openSync('test.ls')
     compiled = new LivescriptCompileView editor.id

--- a/styles/livescript-compile.less
+++ b/styles/livescript-compile.less
@@ -7,7 +7,7 @@
 .livescript-compile {
   overflow: scroll;
 
-  .editor {
+  atom-text-editor::shadow {
     padding-left: 5px;
 
     .lines{


### PR DESCRIPTION
fixed:
1. #2 #3 (use [highlights](https://github.com/atom/highlights))
2. #4 #5 #6
3. #7 #8 (atom.ScrollView is deprecated, i use [atom-space-pen-views](https://github.com/atom/atom-space-pen-views))
